### PR TITLE
Add checking when runtime is not found

### DIFF
--- a/src/wrapping-run.adb
+++ b/src/wrapping-run.adb
@@ -181,14 +181,20 @@ package body Wrapping.Run is
             end loop;
 
             Close (Dir);
+         exception
+            when GNAT.Directory_Operations.Directory_Error =>
+               Warning ("Cannot find the uwrap runtime");
          end Analyze_Directory;
 
       begin
+         --  Lookup the "stdlib": look into the hardcoded "../include"
+         --  directory, used during development. TODO??? we'll probably need
+         --  to do something more clever than this at some stage.
          Analyze_Directory
            ("",
-            GNATCOLL.Utils.Executable_Location & ".." &
-            GNATCOLL.OS.Constants.Dir_Sep & "include" &
-            GNATCOLL.OS.Constants.Dir_Sep);
+            GNATCOLL.Utils.Executable_Location & ".."
+            & GNATCOLL.OS.Constants.Dir_Sep & "include"
+            & GNATCOLL.OS.Constants.Dir_Sep);
 
          for Dir_Path of Input_Directories loop
             Analyze_Directory ("", To_String (Dir_Path));

--- a/src/wrapping.adb
+++ b/src/wrapping.adb
@@ -61,6 +61,19 @@ package body Wrapping is
       end if;
    end Error;
 
+   -------------
+   -- Warning --
+   -------------
+
+   procedure Warning (Message : Text_Type) is
+   begin
+      if Error_Stack.Length > 0 then
+         Put_Line (To_Text (Get_Sloc_Str) & ": warning: " & Message);
+      else
+         Put_Line ("warning: " & Message);
+      end if;
+   end Warning;
+
    -------------------------
    -- Push_Error_Location --
    -------------------------

--- a/src/wrapping.ads
+++ b/src/wrapping.ads
@@ -7,6 +7,8 @@ package Wrapping is
 
    procedure Error (Message : Text_Type);
 
+   procedure Warning (Message : Text_Type);
+
    procedure Push_Error_Location (Filename : String; Loc : Source_Location);
 
    procedure Pop_Error_Location;

--- a/uwrap.gpr
+++ b/uwrap.gpr
@@ -10,7 +10,8 @@ project UWrap is
    for Create_Missing_Dirs use "true";
 
    for Source_Dirs use ("src");
-   for Object_Dir use "obj";
+   for Object_Dir use "obj/" & Build_Mode;
+   for Exec_Dir use "obj";
    for Main use ("uwrap");
 
    package Binder is
@@ -21,7 +22,7 @@ project UWrap is
       case Build_Mode is
          when "dev" =>
             for Default_Switches ("Ada") use
-              ("-g", "-O0", "-gnata",
+              ("-g", "-O0", "-gnata", "-gnatw.T",
                --  TODO: Activate GNAT style checks, except mandatory subprogram
                --  specs, because there are a ton to fix.
                "-gnatyg-s");


### PR DESCRIPTION
- Don't put executable in subdirs
- Add Wrapping.Warning helper

The previous PR broke loading of the stdlib with an obscure exception message, hence the added logging.