### PR TITLE
Fixing bugs with functions prefixing filters

### DIFF
--- a/src/wrapping-runtime-expressions.adb
+++ b/src/wrapping-runtime-expressions.adb
@@ -1303,6 +1303,10 @@ package body Wrapping.Runtime.Expressions is
          --  prefix can't be found.
 
          Match_Mode := Match_Has;
+      else
+         --  Otherwise, don't change the match mode.
+
+         Match_Mode := Top_Context.Match_Mode;
       end if;
 
       Push_Frame_Context_No_Match;

--- a/src/wrapping-runtime-objects.adb
+++ b/src/wrapping-runtime-objects.adb
@@ -709,12 +709,14 @@ package body Wrapping.Runtime.Objects is
 
             Visit_Decision := Process_Generated_Value (Prev_Top);
 
-            if Top_Context.Visit_Decision /= null then
-               Top_Context.Visit_Decision.all := Visit_Decision;
-            end if;
-
             Last_Result := Pop_Object;
             Pop_Frame;
+
+            if Top_Context.Visit_Decision /= null
+              and then Visit_Decision /= Unknown
+            then
+               Top_Context.Visit_Decision.all := Visit_Decision;
+            end if;
          end if;
       end Result_Callback;
 

--- a/testsuite/tests/ada/p_base_types2/expected.out
+++ b/testsuite/tests/ada/p_base_types2/expected.out
@@ -1,0 +1,3 @@
+type F1 is new A and I2 with null record; has an ascendance depth of at least two
+type F2 is new B and I1 with null record; has an ascendance depth of at least two
+

--- a/testsuite/tests/ada/p_base_types2/src/p.gpr
+++ b/testsuite/tests/ada/p_base_types2/src/p.gpr
@@ -1,0 +1,3 @@
+project P is
+
+end P;

--- a/testsuite/tests/ada/p_base_types2/src/pck.ads
+++ b/testsuite/tests/ada/p_base_types2/src/pck.ads
@@ -1,0 +1,15 @@
+package Pck is
+
+    type A is tagged null record;
+
+    type B is new A with null record;
+
+    type I1 is interface;
+
+    type I2 is interface and I1;
+
+    type F1 is new A and I2 with null record;
+
+    type F2 is new B and I1 with null record;    
+
+end Pck;

--- a/testsuite/tests/ada/p_base_types2/test.sh
+++ b/testsuite/tests/ada/p_base_types2/test.sh
@@ -1,0 +1,2 @@
+cd out
+UWRAP "-l ada -w `pwd`/../test.wrp -P `pwd`/../src/p.gpr `pwd`/../src/pck.ads"

--- a/testsuite/tests/ada/p_base_types2/test.wrp
+++ b/testsuite/tests/ada/p_base_types2/test.wrp
@@ -1,0 +1,12 @@
+# this test checks that it's possible to iterate over all the element of an
+# array in a function, and to use such function in a filter recursively
+# calling that function at least twice. We want to verify in particular that
+# iteration control from the filter works propertly, e.g. that when a matching
+# value is found, the iteration in the function stops.
+
+function x () do
+    pick p_base_types ().foreach ().all ();
+end;
+
+match p_base_types () and x ().filter (many (AdaNode (), 2))
+weave standard.out (@ & it & " has an ascendance depth of at least two\n");


### PR DESCRIPTION
In Handle_Filter, we were switching non Match_None match modes to
Match_Has, while forgetting to keep the previous value otherwise, resulting
in uninitialized data. Now fixed.

In Push_Call_Result of a W_Function, the iteration decision was dismissed
and not transmitted to the parent frame. Moved the transmission after
poping the calling frame.

Tests and fixes TA02-001.