### PR TITLE
Fix 'build' in lang_test/Makefile

### DIFF
--- a/lang_test/Makefile
+++ b/lang_test/Makefile
@@ -1,5 +1,5 @@
 build: force
-	rm -rf build/ && ./manage.py --no-langkit-support --library-types static make
+	rm -rf build/ && ./manage.py make --library-types static
 
 parse: force
 	rm -rf build/ && ./manage.py make


### PR DESCRIPTION
The is similar to the earlier fix in lang_template/Makefile.  "make"
in lang_test/ fails, because the invocation of manage.py is wrong.
The "make" command there must come first, and --no-langkit-support
does not appear to be a valid option.